### PR TITLE
Bugfix/make crit calc consistent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "strict"
+}

--- a/Character.py
+++ b/Character.py
@@ -1,4 +1,5 @@
 from Spell import Spell
+from functools import cached_property
 
 class Character:
     intellectPerPoint = 1
@@ -8,14 +9,9 @@ class Character:
     spiritPerPoint = 0.21
     def __init__(self, intellect, crit, expertise, haste, spirit):
         self.intellectPoints = intellect
-        self.intellect = intellect * Character.intellectPerPoint
         self.critPoints = crit
-        self.crit = (crit * Character.critPerPoint) + 5  # % chance (e.g., 5 for 5%)
         self.expertisePoints = expertise
-        self.expertise = expertise * Character.expertisePerPoint  # % increase to damage
         self.hastePoints = haste
-        self.haste = haste * Character.hastePerPoint  # % increase to cast speed
-        self.spirit = spirit * Character.spiritPerPoint
         self.spiritPoints = spirit
         self.mana = 0
         self.winter_orbs = 0
@@ -30,6 +26,29 @@ class Character:
         self.glacial_assault_buff = Spell("Glacial Assault", isBuff=True, debuffDuration=100000)
         self.cometBonus = Spell("Ice Comet", cast_time=0, cooldown=0, mana_generation=0, winter_orb_cost=0, damage_percent=300)
 
+    def _calculate_stat_value(self, points, statPerPoint):
+        return points * statPerPoint
+
+    @cached_property
+    def intellect(self):
+        return self._calculate_stat_value(self.intellectPoints, Character.intellectPerPoint)
+
+    @cached_property
+    def crit(self):
+        return self._calculate_stat_value(self.critPoints, Character.critPerPoint) + 5 #5% base crit
+    
+    @cached_property
+    def expertise(self):
+        return self._calculate_stat_value(self.expertisePoints, Character.expertisePerPoint)
+    
+    @cached_property
+    def haste(self):
+        return self._calculate_stat_value(self.hastePoints, Character.hastePerPoint)
+
+    @cached_property
+    def spirit(self):
+        return self._calculate_stat_value(self.spiritPoints, Character.spiritPerPoint)
+
     def add_spell(self, spell):
         self.spells.append(spell)
     
@@ -37,8 +56,8 @@ class Character:
         self.talents.append(talent)
 
     def update_stats(self, intellect, crit, expertise, haste, spirit):
-        self.intellect = intellect * Character.intellectPerPoint
-        self.crit = crit * Character.critPerPoint
-        self.expertise = expertise * Character.expertisePerPoint
-        self.haste = haste * Character.hastePerPoint
-        self.spirit = spirit * Character.spiritPerPoint
+        self.intellect_points = intellect
+        self.crit_points = crit
+        self.expertise_points = expertise
+        self.haste_points = haste
+        self.spirit_points = spirit


### PR DESCRIPTION
Noticed in the __init__ for Character +5 is added to the crit %, meanwhile Character.update_stats recalculates the % without the +5.

Made final stat values cahced properties to make it easy to keep their calculations consistent.

(I typically make classes with pydantic, unfamiliar with cached_property, hopefully they work the way I expect, no tests currently in the repository, but happy to contribute them now or in the future)