### PR TITLE
Feat/damage table

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ Currently working on:
 **The program supports multiple arguments:**
 
 ```bash
-python main.py -s average_dps -e 5 -d <duration_secs> -t <talent_tree> -p <preset> -c <custom_character>
+python main.py -s average_dps -e 5 -d <duration_secs> -r <run_count> -g <stat_weights_gain> -t <talent_tree> -p <preset> -c <custom_character>
 ```
 
 - `-s <sim_type>`: The type of simulation to run.
 - `-e <enemy_count>`: The number of enemies to simulate.
 - `-d <duration_secs>`: The duration of the simulation in seconds. Default is `120`.
+- `-r <run_count>`: The number of times to run the simulation. Default is `2000`.
+- `-g <stat_weights_gain>`: Stat increase constant when running the simulation. Default is `20`.
 - `-t <talent_tree>`: The talent tree to use. Format must be `{row1}-{row2}-{row3}`.
 - `-p <preset>`: Use a preset character.
 - `-c <custom_character>`: Use a custom character. Format must be `{intellect}-{crit}-{expertise}-{haste}-{spirit}`.
@@ -54,10 +56,10 @@ python main.py -s average_dps -e 5 -d <duration_secs> -t <talent_tree> -p <prese
 ### ✨ Example
 
 ```bash
-python main.py -s average_dps -e 5 -t 2-12-3 -p default -c 100-20-30-40-50
+python main.py -s average_dps -e 5 -d 120 -r 2000 -t 2-12-3 -p default -c 100-20-30-40-50
 ```
 
-This will run the average DPS simulation with 5 enemies, using the default preset and a custom character with 100 intellect, 20 crit, 30 expertise, 40 haste, and 50 spirit. The simulation will run for 120 seconds by default.
+This will run the average DPS simulation with 5 enemies, using the default preset and a custom character with 100 intellect, 20 crit, 30 expertise, 40 haste, and 50 spirit. The simulation will run 2000 times for 120 seconds by default.
 
 ## 👑 Hall of Fame / Credits
 

--- a/Sim.py
+++ b/Sim.py
@@ -394,6 +394,7 @@ class Simulation:
             if spell is None:
                 if self.do_debug:
                     print(f"Time {self.time:.2f}: No ready spell available")
+                self.update_time(0.1)
                 continue
 
             self.gcd = 1.5 / (1 + self.character.haste / 100)

--- a/Sim.py
+++ b/Sim.py
@@ -395,19 +395,17 @@ class Simulation:
                 # Check for spells
                 for test_spell in self.character.rotation:
                     if spell.name != test_spell.name:
-                        print(
-                            spell.name,
-                            spell.effective_cast_time(self.character),
-                        )
                         if (
                             spell.effective_cast_time(self.character) == 0
-                            # and test_spell.remaining_cooldown > 0
+                            and test_spell.remaining_cooldown > 0
                             and test_spell.remaining_cooldown
                             < (1.5 / (1 + self.character.haste / 100))
                         ):
-                            print(
-                                f"Waiting for {test_spell.name} (GCD Trigger)"
-                            )
+                            if self.do_debug:
+                                print(
+                                    f"Waiting for {test_spell.name} "
+                                    + "(GCD Trigger)"
+                                )
                             self.update_time(test_spell.remaining_cooldown)
                             check = True
                             break
@@ -417,38 +415,22 @@ class Simulation:
                             < spell.effective_cast_time(self.character)
                             and test_spell.remaining_cooldown > 0
                         ):
-                            print(f"Waiting for {test_spell.name}")
+                            if self.do_debug:
+                                print(f"Waiting for {test_spell.name}")
                             self.update_time(test_spell.remaining_cooldown)
                             check = True
                             break
+                    else:
+                        break
 
                 if check:
                     continue
-
-            # if spell is not None and spell.name == "Frost Bolt":
-            #     nearest_ready_spell = min(
-            #         (
-            #             s
-            #             for s in self.character.rotation
-            #             if not s.is_ready(self.character, self.enemy_count)
-            #             and s.remaining_cooldown > 0
-            #         ),
-            #         key=lambda s: s.remaining_cooldown,
-            #     )
-            #     if (
-            #         nearest_ready_spell.remaining_cooldown
-            #         <= spell.effective_cast_time(self.character)
-            #     ):
-            #         self.update_time(nearest_ready_spell.remaining_cooldown)
-            #         continue
 
             if spell is None:
                 if self.do_debug:
                     print(f"Time {self.time:.2f}: No ready spell available")
                 self.update_time(0.1)
                 continue
-
-            print(f"Doing {spell.name}")
 
             self.gcd = 1.5 / (1 + self.character.haste / 100)
 

--- a/base/character.py
+++ b/base/character.py
@@ -1,6 +1,6 @@
 """Module for the Character class."""
 
-from typing import List, TYPE_CHECKING
+from typing import Dict, List, TYPE_CHECKING
 
 from characters.Rime import RimeSpell, RimeBuff
 
@@ -36,13 +36,14 @@ class Character:
         self.mana = 0
         self.winter_orbs = 0
         # This will hold the character's available spells.
-        self.spells: List[Spell] = [spell.value for spell in RimeSpell]
+        self.spells: Dict[str, Spell] = {
+            spell.value.name.lower(): spell.value for spell in RimeSpell
+        }
         # This will hold the character's rotation.
         self.rotation: List[Spell] = []
         # All the talents.
         self.talents: List[str] = []
 
-        self.anima_spikes = RimeSpell.ANIMA_SPIKES.value
         self.soulfrost = RimeSpell.SOULFROST_TORRENT.value
         self.boosted_blast = RimeBuff.BOOSTED_BLAST.value
 
@@ -53,7 +54,7 @@ class Character:
     def add_spell_to_rotation(self, spell: RimeSpell) -> None:
         """Adds a spell to the character's rotation."""
 
-        if spell.value not in self.spells:
+        if spell.value.name.lower() not in self.spells:
             raise ValueError(f"Spell {spell} not found in available spells.")
 
         self.rotation.append(spell.value)

--- a/base/spell.py
+++ b/base/spell.py
@@ -59,14 +59,11 @@ class Spell:
     def is_ready(self, character: "Character", enemy_count: int) -> bool:
         """Returns True if the spell is ready to be cast."""
 
-        if (
-            enemy_count >= self.min_target_count
-            and enemy_count <= self.max_target_count
-        ):
-            if self.winter_orb_cost <= character.winter_orbs:
-                if self.remaining_cooldown <= 0:
-                    return True
-        return False
+        return (
+            self.min_target_count <= enemy_count <= self.max_target_count
+            and self.winter_orb_cost <= character.winter_orbs
+            and self.remaining_cooldown <= 0
+        )
 
     def damage(self, character: "Character") -> float:
         """Returns the damage of the spell."""

--- a/main.py
+++ b/main.py
@@ -140,6 +140,7 @@ def main(arguments: argparse.Namespace):
                 arguments.duration,
                 arguments.run_count,
                 arguments.enemy_count,
+                arguments.experimental_feature,
             )
         case "stat_weights":
             stat_weights(
@@ -148,6 +149,7 @@ def main(arguments: argparse.Namespace):
                 arguments.duration,
                 arguments.run_count,
                 arguments.stat_weights_gain,
+                arguments.experimental_feature,
                 arguments.enemy_count,
             )
         case "debug_sim":
@@ -168,6 +170,7 @@ def stat_weights(
     duration: int,
     run_count: int,
     stat_increase: int,
+    use_experimental: bool,
     enemy_count: Optional[int] = None,
 ) -> None:
     """Calculates the stat weights of the character."""
@@ -175,7 +178,13 @@ def stat_weights(
     target_count = 4 if enemy_count is None else enemy_count
     character_base = character
     base_dps = average_dps(
-        table, character_base, duration, run_count, target_count, "base"
+        table,
+        character_base,
+        duration,
+        run_count,
+        target_count,
+        use_experimental=use_experimental,
+        stat_name="base",
     )
 
     def update_stats(
@@ -216,7 +225,8 @@ def stat_weights(
             duration,
             run_count,
             target_count,
-            stat_name,
+            use_experimental=use_experimental,
+            stat_name=stat_name,
         )
 
     int_dps = update_stats(character, stat_increase, "intellect")
@@ -265,6 +275,7 @@ def average_dps(
     duration: int,
     run_count: int,
     enemy_count: int,
+    use_experimental: bool,
     stat_name: Optional[str] = None,
 ) -> float:
     """Runs a simulation and returns the average DPS."""
@@ -320,12 +331,14 @@ def average_dps(
         end_section=True,
     )
 
-    if not stat_name:
+    # Experimental: Damage Table
+    # ---------------------------
+    if not stat_name and use_experimental:
         damage_sum = sum(damage for _, damage in sim.damage_table.items())
 
         table.add_row(
             "[bold yellow]-------- Experimental!",
-            "[bold yellow]----------------",
+            "[bold yellow]Do not trust! --------",
         )
         table.add_row("[white]Damage Table", "[white]-------------")
         for spell, damage in sim.damage_table.items():
@@ -402,6 +415,12 @@ if __name__ == "__main__":
         type=float,
         default=20,
         help="Gain of stat weights for the simulation.",
+    )
+    parser.add_argument(
+        "-x",
+        "--experimental-feature",
+        action="store_true",
+        help="Enable experimental features such as the damage table.",
     )
 
     # Parse arguments.

--- a/main.py
+++ b/main.py
@@ -336,15 +336,33 @@ def average_dps(
     if not stat_name and use_experimental:
         damage_sum = sum(damage for _, damage in sim.damage_table.items())
 
+        # Sort sim.damage_table by damage dealt from highest to lowest.
+        # Remove rows with 0 values
+        sorted_damage_table = {
+            k: v
+            for k, v in sorted(
+                sim.damage_table.items(),
+                key=lambda item: item[1],
+                reverse=True,
+            )
+            if v > 0
+        }
+
         table.add_row(
             "[bold yellow]-------- Experimental!",
             "[bold yellow]Do not trust! --------",
         )
-        table.add_row("[white]Damage Table", "[white]-------------")
-        for spell, damage in sim.damage_table.items():
-            table.add_row(
-                spell, f"[magenta]{round(damage, 3)} ({damage/damage_sum:.2%})"
+
+        # make first 3 rows bold
+        for i, (spell, damage) in enumerate(sorted_damage_table.items()):
+            spell_name = f"[bold]{spell}" if i < 3 else spell
+            damage = (
+                f"[bold dark_red]{round(damage, 3)} ({damage/damage_sum:.2%})"
+                if i < 3
+                else f"[magenta]{round(damage, 3)} ({damage/damage_sum:.2%})"
             )
+
+            table.add_row(spell_name, damage)
 
     return avg_dps
 

--- a/main.py
+++ b/main.py
@@ -41,6 +41,8 @@ def main(arguments: argparse.Namespace):
     table.add_row("Simulation Type", arguments.simulation_type)
     table.add_row("Enemy Count", str(arguments.enemy_count))
     table.add_row("Duration", str(arguments.duration))
+    if arguments.simulation_type == "stat_weights":
+        table.add_row("Stat Weights Gain", str(arguments.stat_weights_gain))
     table.add_row(
         "Preset",
         arguments.preset if arguments.preset else RimePreset.DEFAULT.name,
@@ -133,16 +135,30 @@ def main(arguments: argparse.Namespace):
     match arguments.simulation_type:
         case "average_dps":
             average_dps(
-                table, character, arguments.duration, arguments.enemy_count
+                table,
+                character,
+                arguments.duration,
+                arguments.run_count,
+                arguments.enemy_count,
             )
         case "stat_weights":
             stat_weights(
-                table, character, arguments.duration, arguments.enemy_count
+                table,
+                character,
+                arguments.duration,
+                arguments.run_count,
+                arguments.stat_weights_gain,
+                arguments.enemy_count,
             )
         case "debug_sim":
-            debug_sim(character, arguments.duration, arguments.enemy_count)
+            debug_sim(
+                character,
+                arguments.duration,
+                arguments.enemy_count,
+            )
 
     # Print the final results
+    console.print("\n")
     console.print(table)
 
 
@@ -150,15 +166,16 @@ def stat_weights(
     table: Table,
     character: Character,
     duration: int,
+    run_count: int,
+    stat_increase: int,
     enemy_count: Optional[int] = None,
 ) -> None:
     """Calculates the stat weights of the character."""
 
-    stat_increase = 200
     target_count = 4 if enemy_count is None else enemy_count
     character_base = character
     base_dps = average_dps(
-        table, character_base, duration, target_count, "base"
+        table, character_base, duration, run_count, target_count, "base"
     )
 
     def update_stats(
@@ -197,6 +214,7 @@ def stat_weights(
             table,
             character_updated,
             duration,
+            run_count,
             target_count,
             stat_name,
         )
@@ -207,7 +225,7 @@ def stat_weights(
     haste_dps = update_stats(character, stat_increase, "haste")
     spirit_dps = update_stats(character, stat_increase, "spirit")
 
-    table.add_row("Stat Weights", "[white]-------------")
+    table.add_row("\n[white]Stat Weights", "\n[white]-------------")
     table.add_row(
         "Intellect", f"[magenta]{1 + ((int_dps - base_dps) / base_dps):.2f}"
     )
@@ -245,6 +263,7 @@ def average_dps(
     table: Table,
     character: Character,
     duration: int,
+    run_count: int,
     enemy_count: int,
     stat_name: Optional[str] = None,
 ) -> float:
@@ -262,7 +281,6 @@ def average_dps(
         TextColumn("•"),
         TimeRemainingColumn(),
     ) as progress:
-        run_count = 2000
         dps_running_total = 0
         dps_lowest = float("inf")
         dps_highest = float("-inf")
@@ -288,8 +306,6 @@ def average_dps(
             dps_running_total += dps
         avg_dps = dps_running_total / run_count
 
-        progress.update(task, visible=False)
-
     table.add_row(
         "Average DPS" if not stat_name else f"Average DPS ({stat_name})",
         f"[bold magenta]{avg_dps:.2f}",
@@ -303,6 +319,19 @@ def average_dps(
         f"[bold magenta]{dps_highest:.2f}",
         end_section=True,
     )
+
+    if not stat_name:
+        damage_sum = sum(damage for _, damage in sim.damage_table.items())
+
+        table.add_row(
+            "[bold yellow]-------- Experimental!",
+            "[bold yellow]----------------",
+        )
+        table.add_row("[white]Damage Table", "[white]-------------")
+        for spell, damage in sim.damage_table.items():
+            table.add_row(
+                spell, f"[magenta]{round(damage, 3)} ({damage/damage_sum:.2%})"
+            )
 
     return avg_dps
 
@@ -359,6 +388,20 @@ if __name__ == "__main__":
         type=int,
         default=120,
         help="Duration of the simulation.",
+    )
+    parser.add_argument(
+        "-r",
+        "--run-count",
+        type=int,
+        default=2000,
+        help="Number of runs to average DPS.",
+    )
+    parser.add_argument(
+        "-g",
+        "--stat-weights-gain",
+        type=float,
+        default=20,
+        help="Gain of stat weights for the simulation.",
     )
 
     # Parse arguments.


### PR DESCRIPTION
This pull request includes several changes to the simulation program to add new features and improve functionality. The most important changes include adding new command-line arguments, updating the simulation logic to track and return damage, and modifying the main function to handle new parameters.

### Command-line argument updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R62): Added new arguments `-r <run_count>`, `-g <stat_weights_gain>`, and `-x <experimental_feature>` to the documentation.
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R405-R424): Added parsing for new arguments `--run-count`, `--stat-weights-gain`, and `--experimental-feature`.

### Simulation logic updates:
* [`Sim.py`](diffhunk://#diff-e5e4d31e9b47562e86f46455d03420935a72a497b04c3aabfdafa695e93d8077R30-R31): Added a `damage_table` attribute to track damage for each spell and updated the `do_damage` method to return the damage dealt. [[1]](diffhunk://#diff-e5e4d31e9b47562e86f46455d03420935a72a497b04c3aabfdafa695e93d8077R30-R31) [[2]](diffhunk://#diff-e5e4d31e9b47562e86f46455d03420935a72a497b04c3aabfdafa695e93d8077L92-R114) [[3]](diffhunk://#diff-e5e4d31e9b47562e86f46455d03420935a72a497b04c3aabfdafa695e93d8077R363-R365) [[4]](diffhunk://#diff-e5e4d31e9b47562e86f46455d03420935a72a497b04c3aabfdafa695e93d8077L424-R436) [[5]](diffhunk://#diff-e5e4d31e9b47562e86f46455d03420935a72a497b04c3aabfdafa695e93d8077R500-R501)

### Main function updates:
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R44-R45): Updated the `main` function and related methods to handle the new `run_count`, `stat_weights_gain`, and `experimental_feature` parameters. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R44-R45) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L136-R187) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R226-R229) [[4]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L210-R238) [[5]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R276-R278) [[6]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L265) [[7]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L291-L292) [[8]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R334-R348)